### PR TITLE
Fix build_debug_apk workflow

### DIFF
--- a/.github/workflows/build_debug_apk.yml
+++ b/.github/workflows/build_debug_apk.yml
@@ -1,7 +1,7 @@
 name: Build_debug_apk
 
 on:
-  pull_requests:
+  pull_request:
     branches:
       - 'dev'
 
@@ -11,9 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v2
-        with:
-          java-version: 1.8
+      - uses: actions/setup-java@v1
+        with: {java-version: 11}
 
       - name: Build Project
         run: ./gradlew assembleDebug


### PR DESCRIPTION
Поправлен build_debug_apk workflow. Была допущена ошибка в названии event'a.
Change `pull_requests` to `pull_request`
